### PR TITLE
Fix a long time ping cause app crash

### DIFF
--- a/Sources/SwiftyPing/SwiftyPing.swift
+++ b/Sources/SwiftyPing/SwiftyPing.swift
@@ -532,7 +532,7 @@ public class SwiftyPing: NSObject {
     
     private func incrementSequenceIndex() {
         // Handle overflow gracefully
-        if sequenceIndex >= Int.max {
+        if sequenceIndex >= UInt16.max {
             sequenceIndex = 0
         } else {
             sequenceIndex += 1


### PR DESCRIPTION
UInt16(65536) cause app crash:
```
SwiftyPing.swift 362:
let icmpPackage = try self.createICMPPackage(identifier: UInt16(self.identifier), sequenceNumber: UInt16(self.sequenceIndex))
```
when the sequenceIndex keep plus up to Int.max > 65535 :
```
private func incrementSequenceIndex() {
        // Handle overflow gracefully
        if sequenceIndex >= Int.max {
            sequenceIndex = 0
        } else {
            sequenceIndex += 1
        }
    }
```
<img width="800" alt="Screen Shot 2021-06-08 at 5 09 13 PM" src="https://user-images.githubusercontent.com/39623331/121282312-d9278080-c90b-11eb-97ac-33abb29ff49c.png">


we can fix it to set the max of sequenceIndex to UInt16.max
```
private func incrementSequenceIndex() {
        // Handle overflow gracefully
        if sequenceIndex >= UInt16.max {
            sequenceIndex = 0
        } else {
            sequenceIndex += 1
        }
    }
```